### PR TITLE
Fix pgadmin4 by avoiding volume overriding default directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ x-common:
     PGADMIN_DEFAULT_EMAIL: admin@admin.com
     PGADMIN_DEFAULT_PASSWORD: root
     PGADMIN_PORT: &pgadmin-port "3001:80"
+    PGADMIN_SERVER_JSON_FILE: /pgadmin4-config/servers.json
 #
 # ------------------------------------------------------------------------------------------
 # DANGER ZONE BELOW
@@ -66,7 +67,7 @@ services:
     ports:
       - *pgadmin-port
     volumes:
-      - pgadmin-config:/pgadmin4
+      - pgadmin-config:/pgadmin4-config
     depends_on:
       - postgres
       - pgadmin-config


### PR DESCRIPTION
In fd1d660dda67b4010f8148e960e5f3e03e167a92 a volume is set to override /pgadmin4, which is where the pgadmin code lies, so it cannot start.

This change moves the server JSON to another path, so pgadmin4 can start again.