### PR TITLE
Make pgadmin config persistent and backups accesible for pgadmin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       - *pgadmin-port
     volumes:
       - pgadmin-config:/pgadmin4-config
+      - pgadmin:/var/lib/pgadmin
+      - *bk-location
     depends_on:
       - postgres
       - pgadmin-config
@@ -84,3 +86,4 @@ services:
 
 volumes:
   pgadmin-config:
+  pgadmin:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,13 +69,13 @@ services:
       - pgadmin-config:/pgadmin4-config
       - pgadmin:/var/lib/pgadmin
       - *bk-location
+    entrypoint: "/bin/sh"
     command: 
-      - /bin/sh
       - -c
       - |
-        'mkdir /var/lib/pgadmin/storage/$${PGADMIN_DEFAULT_EMAIL//@/_}/'
-        'ln -s /backups /var/lib/pgadmin/storage/$${PGADMIN_DEFAULT_EMAIL//@/_}/'
-        '/entrypoint.sh'
+        mkdir -p /var/lib/pgadmin/storage/$${PGADMIN_DEFAULT_EMAIL//@/_}/
+        ln -s /backups /var/lib/pgadmin/storage/$${PGADMIN_DEFAULT_EMAIL//@/_}/
+        /entrypoint.sh
     depends_on:
       - postgres
       - pgadmin-config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,13 @@ services:
       - pgadmin-config:/pgadmin4-config
       - pgadmin:/var/lib/pgadmin
       - *bk-location
+    command: 
+      - /bin/sh
+      - -c
+      - |
+        'mkdir /var/lib/pgadmin/storage/$${PGADMIN_DEFAULT_EMAIL//@/_}/'
+        'ln -s /backups /var/lib/pgadmin/storage/$${PGADMIN_DEFAULT_EMAIL//@/_}/'
+        '/entrypoint.sh'
     depends_on:
       - postgres
       - pgadmin-config


### PR DESCRIPTION
Use a volume to have persistent configuration for pgadmin and add backups volume for easier restoring to the pgadmin instance.

To easily find the backups directory inside the pgadmin container, one last step should be made. You should create a symbolic link pointing from your user directory to the backups folder. Something similar to this:

```
docker exec -it resolve_pgadmin sh # To enter in the container with a shell
ln -s /backups /var/lib/pgadmin/storage/admin@admin.com/ # Substitute admin@admin.com with the value for PGADMIN_DEFAULT_EMAIL
```

I tried to add it to the docker-compose file via the "command" argument but I couldn't get it working so far.