### PR TITLE
healtcheck should select database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.8'
 x-common:
   database: &db-environment
-    POSTGRES_DB: database
+    POSTGRES_DB: &pg-db database
     POSTGRES_USER: &pg-user postgres
     POSTGRES_PASSWORD: DaVinci
     TZ: America/Chicago
@@ -37,7 +37,7 @@ services:
     volumes:
       - *db-location
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", *pg-user]
+      test: ["CMD", "pg_isready", "-U", *pg-user, "-d", *pg-db]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
healtcheck defaults to database named like username, right now it's throwing fatal errors - docker logs are full of 
`FATAL: database "<user>" does not exist`

after this change healthcheck selects a proper database
