### PR TITLE
fix version missmatch resulting in failed & empty restore

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       retries: 5
   pgbackups:
     container_name: resolve_pgbackup
-    image: prodrigestivill/postgres-backup-local:17
+    image: prodrigestivill/postgres-backup-local:13
     restart: always
     volumes:
       - *bk-location


### PR DESCRIPTION
reverts 68148bf, fixes #137 

postgres-backup-local version should be kept same as postgres version