### PR TITLE
fix empty servers list in pgadmin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
     restart: always
     environment:
       <<: [*admin-environment]
+      PGADMIN_SERVER_JSON_FILE: /pgadmin4-config/servers.json
     ports:
       - *pgadmin-port
     volumes:
@@ -87,7 +88,6 @@ services:
     restart: on-failure
     environment:
       <<: [*db-environment]
-      PGADMIN_SERVER_JSON_FILE: /pgadmin4-config/servers.json
     volumes:
       - pgadmin-config:/config
 


### PR DESCRIPTION
env `PGADMIN_SERVER_JSON_FILE` was assigned to wrong container, so after pgadmin's first start, server list was empty, now its fixed

